### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#102982

### DIFF
--- a/functions-add-output-binding-cosmos-db/HttpExample.cs
+++ b/functions-add-output-binding-cosmos-db/HttpExample.cs
@@ -16,7 +16,7 @@ namespace My.Functions
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req,
             [CosmosDB(databaseName: "my-database", collectionName: "my-container",
-                ConnectionStringSetting = "CosmosDbConnectionString"
+                Connection = "CosmosDbConnectionString"
                 )]IAsyncCollector<dynamic> documentsOut,
             ILogger log)
         {


### PR DESCRIPTION
Documentation says to use ConnectionStringSetting property of CosmosDBAttribute. This no longer exists in newer versions of the CosmosDB extension. It has since been renamed to Connection