### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#105000

### DIFF
--- a/functions-add-output-binding-cosmos-db/HttpExample.cs
+++ b/functions-add-output-binding-cosmos-db/HttpExample.cs
@@ -15,8 +15,8 @@ namespace My.Functions
         [FunctionName("HttpExample")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req,
-            [CosmosDB(databaseName: "my-database", collectionName: "my-container",
-                ConnectionStringSetting = "CosmosDbConnectionString"
+            [CosmosDB(databaseName: "my-database", containerName: "my-container",
+                Connection = "CosmosDbConnectionString"
                 )]IAsyncCollector<dynamic> documentsOut,
             ILogger log)
         {


### PR DESCRIPTION
Updating the cosmos output binding parameters