### PR TITLE
Updating Cosmos DB samples

### DIFF
--- a/functions-add-output-binding-cosmos-db-isolated/HttpExample.cs
+++ b/functions-add-output-binding-cosmos-db-isolated/HttpExample.cs
@@ -36,7 +36,7 @@ namespace My.Functions
     public class MultiResponse
     {
         [CosmosDBOutput("my-database", "my-container",
-            ConnectionStringSetting = "CosmosDbConnectionString", CreateIfNotExists = true)]
+            Connection = "CosmosDbConnectionSetting", CreateIfNotExists = true)]
         public MyDocument Document { get; set; }
         public HttpResponseData HttpResponse { get; set; }
     }

--- a/functions-add-output-binding-cosmos-db-isolated/functions-add-output-binding-cosmos-db-isolated.csproj
+++ b/functions-add-output-binding-cosmos-db-isolated/functions-add-output-binding-cosmos-db-isolated.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="3.0.9" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.1.0" />

--- a/functions-add-output-binding-cosmos-db/HttpExample.cs
+++ b/functions-add-output-binding-cosmos-db/HttpExample.cs
@@ -15,8 +15,8 @@ namespace My.Functions
         [FunctionName("HttpExample")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req,
-            [CosmosDB(databaseName: "my-database", collectionName: "my-container",
-                ConnectionStringSetting = "CosmosDbConnectionString"
+            [CosmosDB(databaseName: "my-database", containerName: "my-container",
+                Connection = "CosmosDbConnectionSetting"
                 )]IAsyncCollector<dynamic> documentsOut,
             ILogger log)
         {

--- a/functions-add-output-binding-cosmos-db/functions-add-output-binding-cosmos-db.csproj
+++ b/functions-add-output-binding-cosmos-db/functions-add-output-binding-cosmos-db.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>functions_add_output_binding_cosmos_db</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The existing samples are targeting the old V3 Extension and they are being pulled in public documentation https://learn.microsoft.com/en-us/azure/azure-functions/functions-add-output-binding-cosmos-db-vs-code?tabs=isolated-process%2Cv1&pivots=programming-language-csharp#add-an-output-binding