### PR TITLE
Clarify README as snippet source and add links to canonical repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
-# Azure Functions binding examples in C#
+# Azure Functions C# sample snippets repository
 
-The following samples are used as a basis for [Azure Functions 2.x+ binding](https://docs.microsoft.com/azure/azure-functions/functions-triggers-bindings#supported-bindings) examples in C#.  
+This repository contains C# source code snippets used as `:::code` includes in [Azure Functions documentation](https://learn.microsoft.com/azure/azure-functions/). It is **not** intended as a standalone sample or project template.
 
-## Settings and configuration
+## Contents
 
-The *local.settings.example.json* file is provided for your convenience. Rename the file to *local.settings.json* and add your own connection and API values before trying to run the examples in this repo.
+| Folder | Purpose |
+|--------|---------|
+| `http-trigger-isolated/` | HTTP trigger (isolated worker, ASP.NET Core integration) |
+| `http-trigger-template/` | HTTP trigger from template |
+| `functions-add-output-binding-storage-queue-isolated/` | HTTP trigger + Storage Queue output (isolated worker) |
+| `functions-add-output-binding-storage-queue-cli/` | HTTP trigger + Storage Queue output (in-process, legacy) |
+| `functions-add-output-binding-storage-queue-vs/` | HTTP trigger + Storage Queue output (Visual Studio) |
+| `functions-add-output-binding-cosmos-db-isolated/` | HTTP trigger + Cosmos DB output (isolated worker) |
+| `functions-add-output-binding-cosmos-db/` | HTTP trigger + Cosmos DB output (in-process, legacy) |
 
-If you're using Visual Studio Code, you can use the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension with the *routes.http* file. This file gives you the ability to call sample functions with a single click inside VS Code.
+## Canonical scenario repositories
 
-## Samples
+If you're looking for complete, deployable Azure Functions projects in C#, use these `azd`-compatible templates instead:
 
-The following samples are available in this repo.
-
-| Name | Description  | Trigger | Input | Output |
-|------|--------------|---------|-------|--------|
-| [HttpTriggerDemo](HttpTriggerDemo.cs) | Triggered by an HTTP request. | Http | N/A | Http |
-| [HttpTriggerRoutes](HttpTriggerRoutes.cs) | Triggered by an HTTP request, configured with a custom route. | Http | N/A | Http |
+- [functions-quickstart-dotnet-azd](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd) — HTTP trigger
+- [functions-quickstart-dotnet-azd-timer](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-timer) — Timer trigger
+- [functions-quickstart-dotnet-azd-cosmosdb](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-cosmosdb) — Azure Cosmos DB trigger
+- [functions-quickstart-dotnet-azd-eventhub](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-eventhub) — Event Hubs trigger
+- [functions-quickstart-dotnet-azd-sql](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-sql) — Azure SQL trigger


### PR DESCRIPTION
- Clarify that this repo is a `:::code` snippet source for Azure Functions docs (not a standalone template)
- Document folder contents and their purposes
- Add links to canonical azd-compatible .NET quickstart repos
- Remove YAML frontmatter (not needed for snippet repos)